### PR TITLE
README.md ... fix URL to www.micropython.org

### DIFF
--- a/rfb/README.md
+++ b/rfb/README.md
@@ -1,4 +1,4 @@
-#VNC's Remote Framebuffer Protocol for [MicroPython](www.micropython.org)
+#VNC's Remote Framebuffer Protocol for [MicroPython](http://www.micropython.org)
 
 _Unsecured_ [Remote Framebuffer Protocol](https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst) (RFB) server implementations (the protocol used by VNC) for [MicroPython](www.micropython.org) (and [cpython](http://www.python.org)).
 


### PR DESCRIPTION
...addedd prefix http:// to www.micropython.org URL in heading.
