### PR TITLE
fix I2C call in readme

### DIFF
--- a/bh1750/README.MD
+++ b/bh1750/README.MD
@@ -8,14 +8,15 @@ Only tested on the esp8266 micropython port.
 import machine
 from bh1750 import BH1750
 
-scl = machine.Pin(5)
-sda = machine.Pin(4)
-i2c = machine.I2C(scl,sda)
+scl_pin = machine.Pin(5)
+sda_pin = machine.Pin(4)
+i2c = machine.I2C(scl=scl_pin, sda=sda_pin)
 
-s = BH1750(i2c)
+sensor = BH1750(i2c)
 
 while True:
-    s.luminance(BH1750.ONCE_HIRES_1)
+    result = sensor.luminance(BH1750.ONCE_HIRES_1)
+    print(result)
 ```
 
 ## Address


### PR DESCRIPTION
Kept getting this error:

```python
>>> from bh1750 import BH1750
>>> scl = machine.Pin(2)
>>> sda = machine.Pin(15)
>>> i2c = machine.I2C(scl,sda)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: invalid I2C peripheral
```

use keyword args instead because first param of `I2C` is the `id`: http://docs.micropython.org/en/latest/pyboard/library/machine.I2C.html#constructors